### PR TITLE
Improve stability of focal loss impl

### DIFF
--- a/effdet/loss.py
+++ b/effdet/loss.py
@@ -59,7 +59,7 @@ def focal_loss(logits, targets, alpha: float, gamma: float, normalizer):
     # samples is:
     #      (1 - p_t)^r = exp(-r * z * x - r * log(1 + exp(-x))).
     neg_logits = -1.0 * logits
-    modulator = torch.exp(gamma * targets * neg_logits - gamma * torch.log1p(torch.exp(neg_logits)))
+    modulator = torch.exp(gamma * targets * neg_logits - gamma * torch.logaddexp(neg_logits, 0))
     loss = modulator * cross_entropy
     weighted_loss = torch.where(positive_label_mask, alpha * loss, (1.0 - alpha) * loss)
     weighted_loss /= normalizer


### PR DESCRIPTION
`torch.exp(neg_logits)` will give a NaN for a large negative value of `neg_logits`. Prevent this by replacing `torch.log1p(torch.exp(neg_logits))` with `torch.logaddexp(neg_logits, 0)`.

`logaddexp(x, y)` is `log(exp(x) + exp(y))`, so `logaddexp(x, 0)` is `log(exp(x) + 1)`. This is equivalent to `log1p(exp(x))` which is just `log(exp(x) + 1)`.

The implementation of `logaddexp` does not return a `NaN` if the operands are very large. It is equivalent to `max(x, y) + log(1 + exp(-1 * abs(x - y)))`. This forces the `exp` to be called with a large negative value instead of a large positive value.

I'm not clear on how this changes the back-propagation behaviour. Also, I think `logaddexp` was only available from pytorch 1.6.0.