### PR TITLE
Fix RuntimeError. torch 1.12

### DIFF
--- a/effdet/loss.py
+++ b/effdet/loss.py
@@ -94,7 +94,7 @@ def huber_loss(
     linear = abs_err - quadratic
     loss = 0.5 * quadratic.pow(2) + delta * linear
     if weights is not None:
-        loss *= weights
+        loss = loss.mul(weights)
     if size_average:
         return loss.mean()
     else:


### PR DESCRIPTION
PyTorch 1.12

```
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "/xxxxx/efficientdet-pytorch/effdet/loss.py", line 210, in loss_fn
        cls_losses.append(cls_loss.sum())   # FIXME reference code added a clamp here at some point ...clamp(0, 2))

        box_losses.append(_box_loss(
                          ~~~~~~~~~ <--- HERE
            box_outputs[l].permute(0, 2, 3, 1).float(),
            box_targets_at_level,
  File "/xxxxx/efficientdet-pytorch/effdet/loss.py", line 134, in _box_loss
    normalizer = num_positives * 4.0
    mask = box_targets != 0.0
    box_loss = huber_loss(box_outputs, box_targets, weights=mask, delta=delta, size_average=False)
               ~~~~~~~~~~ <--- HERE
    return box_loss / normalizer
  File "/xxxxx/efficientdet-pytorch/effdet/loss.py", line 97, in huber_loss
    loss = 0.5 * quadratic.pow(2) + delta * linear
    if weights is not None:
        loss *= weights
        ~~~~~~~~~~~~~~~ <--- HERE
    if size_average:
        return loss.mean()
RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation.
```