### PR TITLE
fix numpy 1.24 errors

### DIFF
--- a/effdet/evaluation/metrics.py
+++ b/effdet/evaluation/metrics.py
@@ -18,7 +18,7 @@ def compute_precision_recall(scores, labels, num_gt):
     if not isinstance(labels, np.ndarray) or len(labels.shape) != 1:
         raise ValueError("labels must be single dimension numpy array")
 
-    if labels.dtype != np.float and labels.dtype != np.bool:
+    if labels.dtype != np.float_ and labels.dtype != np.bool_:
         raise ValueError("labels type must be either bool or float")
 
     if not isinstance(scores, np.ndarray) or len(scores.shape) != 1:
@@ -64,7 +64,7 @@ def compute_average_precision(precision, recall):
 
     if not isinstance(precision, np.ndarray) or not isinstance(recall, np.ndarray):
         raise ValueError("precision and recall must be numpy array")
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != np.float_ or recall.dtype != np.float_:
         raise ValueError("input must be float numpy array.")
     if len(precision) != len(recall):
         raise ValueError("precision and recall must be of the same size.")


### PR DESCRIPTION
Reasons:
DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations